### PR TITLE
WIP - Use external_deploy_tasks to run ansible instead of Mistral

### DIFF
--- a/docker/services/vxflexos-ansible/vxflexos-base.yaml
+++ b/docker/services/vxflexos-ansible/vxflexos-base.yaml
@@ -117,10 +117,6 @@ outputs:
         config_volume: ''
         step_config: ''
       docker_config: {}
-      workflow_tasks: 
-        step2:
-          - name: vxflexos_base_ansible_workflow
-            workflow: {get_param: VxFlexAnsibleWorkflowName}
       config_settings:
         vxflexos_common_ansible_vars:
           cluster_name: {get_param: VxFlexOSClusterName}

--- a/docker/services/vxflexos-ansible/vxflexos-lia.yaml
+++ b/docker/services/vxflexos-ansible/vxflexos-lia.yaml
@@ -53,14 +53,16 @@ outputs:
         config_volume: ''
         step_config: ''
       docker_config: {}
-      workflow_tasks:  {get_attr: [VxFlexOSBase, role_data, workflow_tasks]}
-      config_settings:
-        map_merge:
-        - tripleo.vxflexos_lia.firewall_rules:
-            '202 vxflexos_lia_listener':
-              dport:
-              - '9099'
-        - vxflexos_lia_ansible_vars:
+      external_deploy_tasks:
+        - name: Install PowerFlexLIA
+          when: step|int == 5
+          import_role:
+            name: vxflexos-lia
+          vars:
             map_merge:
             - {get_attr: [VxFlexOSBase, role_data, config_settings, vxflexos_common_ansible_vars]}
-      
+      config_settings:
+        tripleo.vxflexos_lia.firewall_rules:
+          '202 vxflexos_lia_listener':
+            dport:
+            - '9099'


### PR DESCRIPTION
We don't want to call Ansible from Mistral workflows going forward, and
use the external_deploy_tasks interface which will help to run any
Ansible tasks or roles directly.